### PR TITLE
Grid and Enemy to use a Player shared pointer

### DIFF
--- a/roguelike/Enemy.cpp
+++ b/roguelike/Enemy.cpp
@@ -5,11 +5,10 @@
 
 const char Enemy::enemySymbol = '!';
 
-void Enemy::MoveTowardsPlayer(int playerX, int playerY, 
-	const std::vector< std::vector<char>>& grid, int colSize, int rowSize)
+void Enemy::MoveTowardsPlayer(const std::vector< std::vector<char>>& grid, int colSize, int rowSize)
 {
 	// move right towards player
-	if (x < playerX)
+	if (x < _player->GetX())
 	{
 		if ((x < rowSize - 1) &&
 			(grid[x + 1][y] != Grid::wallSymbol))
@@ -19,7 +18,7 @@ void Enemy::MoveTowardsPlayer(int playerX, int playerY,
 		}
 	}
 
-	if (x > playerX) 
+	if (x > _player->GetX()) 
 	{	
 		if ((x > 1) &&
 			(grid[x - 1][y] != Grid::wallSymbol))
@@ -29,7 +28,7 @@ void Enemy::MoveTowardsPlayer(int playerX, int playerY,
 		}
 	}
 
-	if (y < playerY)
+	if (y < _player->GetY())
 	{
 		if ((y < colSize - 1) &&
 			(grid[x][y + 1] != Grid::wallSymbol))
@@ -39,7 +38,7 @@ void Enemy::MoveTowardsPlayer(int playerX, int playerY,
 		}
 	}
 
-	if (y > playerY)
+	if (y > _player->GetY())
 	{
 		if ((y > 1) &&
 			(grid[x][y - 1] != Grid::wallSymbol))
@@ -50,10 +49,10 @@ void Enemy::MoveTowardsPlayer(int playerX, int playerY,
 	}
 }
 
-bool Enemy::CheckForPlayer(int &playerX, int &playerY) 
+bool Enemy::CheckForAdjacentPlayer() 
 {
-	int xDifference = abs(getY() - playerY);
-	int yDifference = abs(getX() - playerX);
+	const int xDifference = abs(getY() - _player->GetX());
+	const int yDifference = abs(getX() - _player->GetY());
 
 	return (xDifference == 1 && yDifference == 0) || (xDifference == 0 && yDifference == 1);
 }

--- a/roguelike/Enemy.h
+++ b/roguelike/Enemy.h
@@ -7,13 +7,11 @@
 
 class Enemy {
 public:
-	Enemy() {}
-	Enemy(int xPos, int yPos) : x{ xPos }, y{ yPos } { }
-	Enemy(int xPos, int yPos, int hp) : x{ xPos }, y{ yPos }, health{ hp } {}
+    Enemy(std::shared_ptr<Player> playerPtr) : _player{playerPtr} {}
+    Enemy(const int xPos, const int yPos, std::shared_ptr<Player> playerPtr) : x{xPos}, y{yPos}, _player{playerPtr} {}
+    Enemy(const int xPos, const int yPos, const int hp, std::shared_ptr<Player> playerPtr) : x{xPos}, y{yPos}, health{hp}, _player{playerPtr} {}
 
-	void MoveTowardsPlayer(int playerX, int playerY, 
-		const std::vector< std::vector<char>>& grid, 
-		int colSize, int rowSize);
+	void MoveTowardsPlayer(const std::vector< std::vector<char>>& grid, int colSize, int rowSize);
 
 	int getX() { return x; }
 	int getY() { return y; }
@@ -22,14 +20,12 @@ public:
 
 	int GetAttackDamage();
 
-	void setPosition(int xPos, int yPos) {
+	void setPosition(const int xPos, const int yPos) {
 		x = xPos;
 		y = yPos;
 	}
 
 	static const char enemySymbol;
-
-	static void SetPlayerReference(Player* playerPtr) { _player = playerPtr; }
 
 private:
 	int x{ 0 }, y{ 0 };
@@ -39,7 +35,7 @@ private:
 	std::random_device rd;
 	std::mt19937 mt;
 
-	static Player* _player;
+    std::shared_ptr<Player> _player;
 	
-	bool CheckForPlayer(int &playerX, int &playerY);
+	bool CheckForAdjacentPlayer();
 };

--- a/roguelike/Grid.cpp
+++ b/roguelike/Grid.cpp
@@ -64,7 +64,7 @@ void Grid::moveUp()
 			_player->DoAttack(0, 0);
 		}
 		_player->SetX(_player->GetX() - 1);
-		enemy.MoveTowardsPlayer(_player->GetX(), _player->GetY(), grid, _colSize, _rowSize);
+		enemy.MoveTowardsPlayer(grid, _colSize, _rowSize);
 	}
 }
 
@@ -84,7 +84,7 @@ void Grid::moveDown()
 		}
 		
 		_player->SetX(_player->GetX() + 1);
-		enemy.MoveTowardsPlayer(_player->GetX(), _player->GetY(), grid, _colSize, _rowSize);
+		enemy.MoveTowardsPlayer(grid, _colSize, _rowSize);
 	}
 
 }
@@ -104,7 +104,7 @@ void Grid::moveLeft()
 		}
 		
 		_player->SetY(_player->GetY() - 1);
-		enemy.MoveTowardsPlayer(_player->GetX(), _player->GetY(), grid, _colSize, _rowSize);
+		enemy.MoveTowardsPlayer(grid, _colSize, _rowSize);
 	};
 }
 
@@ -123,7 +123,7 @@ void Grid::moveRight()
 		}
 		
 		_player->SetY(_player->GetY() + 1);
-		enemy.MoveTowardsPlayer(_player->GetX(), _player->GetY(), grid, _colSize, _rowSize);
+		enemy.MoveTowardsPlayer(grid, _colSize, _rowSize);
 	}
 }
 

--- a/roguelike/Grid.h
+++ b/roguelike/Grid.h
@@ -9,12 +9,12 @@
 
 class Grid {
 public:
-	Grid(int rowSize, int columnSize, Player *playerPtr) 
+	Grid(int rowSize, int columnSize, std::shared_ptr<Player> playerPtr) 
 		: _rowSize{rowSize},
 		  _colSize{columnSize},
 		_player{playerPtr},
 			mt{rd()},
-		enemy{3, 4}
+		enemy{3, 4, playerPtr}
 	{
 		initialize_cells();
 	};
@@ -87,7 +87,7 @@ private:
 	int _colSize;
 
 	Enemy enemy;
-	Player *_player;
+    std::shared_ptr<Player> _player;
 
 	std::vector<Item*> inventory;
 };

--- a/roguelike/main.cpp
+++ b/roguelike/main.cpp
@@ -11,10 +11,8 @@ int main()
 	const int ColumnSize = 100;
 	const int RowSize = 20;
 
-	Player player;
-	Grid grid(RowSize, ColumnSize, &player);
-
-	// Set the player reference for the Enemy class.
+    std::shared_ptr<Player> player = std::make_shared<Player>();
+	Grid grid(RowSize, ColumnSize, player);
 	
 
 	bool isRunning{ true };
@@ -24,11 +22,11 @@ int main()
 		system("cls");
 		grid.print_dungeon();
 
-		if (player.IsDamaged()) {
-			std::cout << "You were hit for " << player.GetLastDamageAmount() << '\n'; 
+		if (player->IsDamaged()) {
+			std::cout << "You were hit for " << player->GetLastDamageAmount() << '\n'; 
 		}
 
-		if (player.GetHealth() <= 0)
+		if (player->GetHealth() <= 0)
 		{ 
 			std::cout << "You are dead!";
 			isRunning = false;


### PR DESCRIPTION
The grid and enemy classes now access the player instance via a shared pointer. This could be further developed to remove the tight grid-player integration.